### PR TITLE
download ziped segemental calls dir, still not working

### DIFF
--- a/statina/API/external/api/api_v1/endpoints/download.py
+++ b/statina/API/external/api/api_v1/endpoints/download.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import FileResponse, RedirectResponse
 
 from statina.adapter.plugin import StatinaAdapter
@@ -9,14 +9,8 @@ from statina.config import get_nipt_adapter
 from statina.crud.find import find
 from statina.models.database import User, DataBaseSample
 from statina.parse.batch import validate_file_path
-
-
-from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile
-
 from os import PathLike
-import io
-
 from typing import Union, Optional
 
 router = APIRouter()

--- a/statina/API/external/api/api_v1/endpoints/download.py
+++ b/statina/API/external/api/api_v1/endpoints/download.py
@@ -16,14 +16,14 @@ from typing import Union, Optional
 router = APIRouter()
 
 
-def zip_dir(zip_name: str, source_dir: Union[str, PathLike], suffix: Optional[str] = None):
-    """Function for zipping"""
-    src_path = Path(source_dir).expanduser().resolve(strict=True)
-    with ZipFile(zip_name, "w", ZIP_DEFLATED) as zf:
-        for file in src_path.rglob("*"):
-            if suffix and file.suffix != suffix:
-                continue
-            zf.write(file, file.relative_to(src_path.parent))
+# def zip_dir(zip_name: str, source_dir: Union[str, PathLike], suffix: Optional[str] = None):
+# """Function for zipping"""
+# src_path = Path(source_dir).expanduser().resolve(strict=True)
+# with ZipFile(zip_name, "w", ZIP_DEFLATED) as zf:
+#    for file in src_path.rglob("*"):
+#        if suffix and file.suffix != suffix:
+#            continue
+#        zf.write(file, file.relative_to(src_path.parent))
 
 
 @router.get("/batch_download/{batch_id}/{file_id}")
@@ -42,14 +42,16 @@ def batch_download(
 
     path = Path(file_path)
     if path.is_dir():
-        zip_file_name = f"{batch_id}_segmental_calls.zip"
-        path = Path(zip_file_name)
-        zip_dir(zip_name=zip_file_name, source_dir=file_path, suffix="bed")
-        return FileResponse(
-            str(path.absolute()),
-            media_type="application/x-zip-compressed",
-            headers={"Content-Disposition": f"attachment;filename={zip_file_name}"},
-        )
+        return RedirectResponse(request.headers.get("referer"))
+        # needs to be fixed
+        # zip_file_name = f"{batch_id}_segmental_calls.zip"
+        # path = Path(zip_file_name)
+        # zip_dir(zip_name=zip_file_name, source_dir=file_path, suffix="bed")
+        # return FileResponse(
+        #    str(path.absolute()),
+        #    media_type="application/x-zip-compressed",
+        #    headers={"Content-Disposition": f"attachment;filename={zip_file_name}"},
+        # )
 
     return FileResponse(
         str(path.absolute()), media_type="application/octet-stream", filename=path.name

--- a/statina/API/external/api/api_v1/endpoints/download.py
+++ b/statina/API/external/api/api_v1/endpoints/download.py
@@ -1,16 +1,35 @@
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import FileResponse, RedirectResponse
 
 from statina.adapter.plugin import StatinaAdapter
 from statina.API.external.api.deps import get_current_user
 from statina.config import get_nipt_adapter
 from statina.crud.find import find
-from statina.models.database import User
+from statina.models.database import User, DataBaseSample
 from statina.parse.batch import validate_file_path
 
+
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from os import PathLike
+import io
+
+from typing import Union, Optional
+
 router = APIRouter()
+
+
+def zip_dir(zip_name: str, source_dir: Union[str, PathLike], suffix: Optional[str] = None):
+    """Function for zipping"""
+    src_path = Path(source_dir).expanduser().resolve(strict=True)
+    with ZipFile(zip_name, "w", ZIP_DEFLATED) as zf:
+        for file in src_path.rglob("*"):
+            if suffix and file.suffix != suffix:
+                continue
+            zf.write(file, file.relative_to(src_path.parent))
 
 
 @router.get("/batch_download/{batch_id}/{file_id}")
@@ -24,11 +43,19 @@ def batch_download(
     """View for batch downloads"""
     batch: dict = find.batch(adapter=adapter, batch_id=batch_id).dict()
     file_path = batch.get(file_id)
-
     if not validate_file_path(file_path):
         return RedirectResponse(request.headers.get("referer"))
 
     path = Path(file_path)
+    if path.is_dir():
+        zip_file_name = f"{batch_id}_segmental_calls.zip"
+        path = Path(zip_file_name)
+        zip_dir(zip_name=zip_file_name, source_dir=file_path, suffix="bed")
+        return FileResponse(
+            str(path.absolute()),
+            media_type="application/x-zip-compressed",
+            headers={"Content-Disposition": f"attachment;filename={zip_file_name}"},
+        )
 
     return FileResponse(
         str(path.absolute()), media_type="application/octet-stream", filename=path.name
@@ -45,8 +72,8 @@ def sample_download(
 ):
     """View for sample downloads"""
 
-    sample: dict = find.sample(adapter=adapter, sample_id=sample_id).dict()
-    file_path = sample.get(file_id)
+    sample: DataBaseSample = find.sample(adapter=adapter, sample_id=sample_id)
+    file_path = sample.dict().get(file_id)
     if not validate_file_path(file_path):
         # warn file missing!
         return RedirectResponse(request.headers.get("referer"))

--- a/statina/API/external/api/api_v1/templates/batch/header.html
+++ b/statina/API/external/api/api_v1/templates/batch/header.html
@@ -26,7 +26,7 @@
                             QC</a>
                         <li class="divider"></li>
                         <a class="dropdown-item"
-                           href="{{ url_for('batch_download', file_id='fluffy_result_file', batch_id=batch.batch_id) }}">Fluffy
+                           href="{{ url_for('batch_download', file_id='result_file', batch_id=batch.batch_id) }}">Fluffy
                             Result file</a>
                         <li class="divider"></li>
                         <a class="dropdown-item"

--- a/statina/parse/batch.py
+++ b/statina/parse/batch.py
@@ -34,13 +34,9 @@ def validate_file_path(file_path: Optional[str]) -> bool:
 
     if not file_path:
         return False
-
     file = Path(file_path)
-
-    if not file.exists():
-        return False
-
-    return True
+    print(file.exists())
+    return bool(file.exists())
 
 
 def convert_empty_str_to_none(data: dict) -> dict:

--- a/statina/parse/batch.py
+++ b/statina/parse/batch.py
@@ -35,7 +35,6 @@ def validate_file_path(file_path: Optional[str]) -> bool:
     if not file_path:
         return False
     file = Path(file_path)
-    print(file.exists())
     return bool(file.exists())
 
 


### PR DESCRIPTION
This PR 
- fixes download of fluffy result file
- tries do fix batch download of segmental calls without sucsess - can be fixed later. Not urgent according to Agne. 

**Review:**
- [ ] code approved by
- [x] tests executed by @mayabrandi 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

