### PR TITLE
Publish to pypi on releases instead of tag

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,9 +1,9 @@
 name: Publish to PyPI
 
 on:
- push:
-  tags:
-   - '*'
+ release:
+  types:
+   - created
 
 jobs:
  build-n-publish:


### PR DESCRIPTION
This PR adds/fixes ...
Trigger action on releases, since github-action-bot is not allowed to trigger cascading workflows 

**How to prepare for test**:
- [ ] paxa statina on cg-services-stage
- [ ] login to cg-services-stage as hiseq-clinical
- [ ] `cd git/servers/resources/CGVS && bash update-statina.sh`

**How to test**:
- [ ] go to statina-stage.scilifelab.se
- [ ] do ...

**Expected test outcome**:
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Bump version
- [ ] Deploy this branch
- [ ] Inform to ...
