### PR TITLE
Validate user is in control of their email address at registration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ python-jose
 bcrypt
 numpy
 aiofiles
+sendmail-container

--- a/statina/API/external/api/api_v1/endpoints/login.py
+++ b/statina/API/external/api/api_v1/endpoints/login.py
@@ -34,7 +34,7 @@ def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()) -> 
     )
 
 
-@router.put("/validate_user/{username}/{verification_hex}")
+@router.post("/validate_user")
 async def validate_user(
     username: str,
     verification_hex: str,
@@ -42,17 +42,20 @@ async def validate_user(
 ):
     update_user: User = find.user(user_name=username, adapter=adapter)
     if update_user.verification_hex == verification_hex:
-        update_user.role = "inactive"
-        update.update_user(adapter=adapter, user=update_user)
-        email_form = FormDataRequest(
-            sender_prefix=email_settings.sender_prefix,
-            request_uri=email_settings.mail_uri,
-            recipients=email_settings.admin_email,
-            mail_title="New user request",
-            mail_body=f"User {update_user.username} ({update_user.email}) requested new account <br>"
-            f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
-        )
-        email_form.submit()
+        try:
+            update_user.role = "inactive"
+            update.update_user(adapter=adapter, user=update_user)
+            email_form = FormDataRequest(
+                sender_prefix=email_settings.sender_prefix,
+                request_uri=email_settings.mail_uri,
+                recipients=email_settings.admin_email,
+                mail_title="New user request",
+                mail_body=f"User {update_user.username} ({update_user.email}) requested new account <br>"
+                f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
+            )
+            email_form.submit()
+        except Exception as e:
+            return str(e)
 
 
 @router.get("/logout")

--- a/statina/API/external/api/api_v1/endpoints/login.py
+++ b/statina/API/external/api/api_v1/endpoints/login.py
@@ -54,8 +54,14 @@ async def validate_user(
             email_form.submit()
             update_user.role = "inactive"
             update.update_user(adapter=adapter, user=update_user)
+            response = RedirectResponse("../batches")
+            response.set_cookie(
+                key="user_info",
+                value="Email confirmed! Your account will be activated after manual review",
+            )
+            return response
         except Exception as e:
-            return str(e)
+            return str(e.__class__.__name__)
 
 
 @router.get("/logout")

--- a/statina/API/external/api/api_v1/endpoints/login.py
+++ b/statina/API/external/api/api_v1/endpoints/login.py
@@ -50,6 +50,8 @@ async def validate_user(
         )
     elif update_user.verification_hex == verification_hex and update_user.role == "unconfirmed":
         try:
+            update_user.role = "inactive"
+            update.update_user(adapter=adapter, user=update_user)
             email_form = FormDataRequest(
                 sender_prefix=email_settings.sender_prefix,
                 request_uri=email_settings.mail_uri,
@@ -59,8 +61,6 @@ async def validate_user(
                 f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
             )
             email_form.submit()
-            update_user.role = "inactive"
-            update.update_user(adapter=adapter, user=update_user)
             response.set_cookie(
                 key="user_info",
                 value="Email confirmed! Your account will be activated after manual review",

--- a/statina/API/external/api/api_v1/endpoints/login.py
+++ b/statina/API/external/api/api_v1/endpoints/login.py
@@ -4,9 +4,13 @@ from typing import Optional
 from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
+from sendmail_container import FormDataRequest
 
 from statina.API.external.api.deps import authenticate_user, create_access_token
-from statina.config import settings
+from statina.adapter import StatinaAdapter
+from statina.config import settings, get_nipt_adapter, email_settings
+from statina.crud import update
+from statina.crud.find import find
 from statina.models.database import User
 
 router = APIRouter()
@@ -28,6 +32,27 @@ def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()) -> 
         form_data=form_data,
         expires_delta=access_token_expires,
     )
+
+
+@router.put("/validate_user/{username}/{verification_hex}")
+async def validate_user(
+    username: str,
+    verification_hex: str,
+    adapter: StatinaAdapter = Depends(get_nipt_adapter),
+):
+    update_user: User = find.user(user_name=username, adapter=adapter)
+    if update_user.verification_hex == verification_hex:
+        update_user.role = "inactive"
+        update.update_user(adapter=adapter, user=update_user)
+        email_form = FormDataRequest(
+            sender_prefix=email_settings.sender_prefix,
+            request_uri=email_settings.mail_uri,
+            recipients=email_settings.admin_email,
+            mail_title="New user request",
+            mail_body=f"User {update_user.username} ({update_user.email}) requested new account <br>"
+            f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
+        )
+        email_form.submit()
 
 
 @router.get("/logout")

--- a/statina/API/external/api/api_v1/endpoints/login.py
+++ b/statina/API/external/api/api_v1/endpoints/login.py
@@ -34,7 +34,7 @@ def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()) -> 
     )
 
 
-@router.post("/validate_user")
+@router.get("/validate_user")
 async def validate_user(
     username: str,
     verification_hex: str,

--- a/statina/API/external/api/api_v1/endpoints/login.py
+++ b/statina/API/external/api/api_v1/endpoints/login.py
@@ -43,8 +43,6 @@ async def validate_user(
     update_user: User = find.user(user_name=username, adapter=adapter)
     if update_user.verification_hex == verification_hex:
         try:
-            update_user.role = "inactive"
-            update.update_user(adapter=adapter, user=update_user)
             email_form = FormDataRequest(
                 sender_prefix=email_settings.sender_prefix,
                 request_uri=email_settings.mail_uri,
@@ -54,6 +52,8 @@ async def validate_user(
                 f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
             )
             email_form.submit()
+            update_user.role = "inactive"
+            update.update_user(adapter=adapter, user=update_user)
         except Exception as e:
             return str(e)
 

--- a/statina/API/external/api/api_v1/endpoints/login.py
+++ b/statina/API/external/api/api_v1/endpoints/login.py
@@ -4,13 +4,11 @@ from typing import Optional
 from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
-from sendmail_container import FormDataRequest
 
 from statina.API.external.api.deps import authenticate_user, create_access_token
-from statina.adapter import StatinaAdapter
-from statina.config import settings, get_nipt_adapter, email_settings
-from statina.crud import update
-from statina.crud.find import find
+
+from statina.config import settings
+
 from statina.models.database import User
 
 router = APIRouter()
@@ -32,46 +30,6 @@ def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()) -> 
         form_data=form_data,
         expires_delta=access_token_expires,
     )
-
-
-@router.get("/validate_user")
-async def validate_user(
-    username: str,
-    verification_hex: str,
-    adapter: StatinaAdapter = Depends(get_nipt_adapter),
-):
-    update_user: User = find.user(user_name=username, adapter=adapter)
-    response = RedirectResponse("../batches")
-    if not update_user:
-        response.set_cookie(key="info_type", value="danger")
-        response.set_cookie(
-            key="user_info",
-            value="No such user in the database",
-        )
-    elif update_user.verification_hex == verification_hex and update_user.role == "unconfirmed":
-        try:
-            update_user.role = "inactive"
-            update.update_user(adapter=adapter, user=update_user)
-            email_form = FormDataRequest(
-                sender_prefix=email_settings.sender_prefix,
-                request_uri=email_settings.mail_uri,
-                recipients=email_settings.admin_email,
-                mail_title="New user request",
-                mail_body=f"User {update_user.username} ({update_user.email}) requested new account <br>"
-                f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
-            )
-            email_form.submit()
-            response.set_cookie(
-                key="user_info",
-                value="Email confirmed! Your account will be activated after manual review",
-            )
-        except Exception as e:
-            response.set_cookie(key="info_type", value="danger")
-            response.set_cookie(
-                key="user_info",
-                value=f"Backend error ({e.__class__.__name__})! Your account will be activated after manual review",
-            )
-    return response
 
 
 @router.get("/logout")

--- a/statina/API/external/api/api_v1/endpoints/update.py
+++ b/statina/API/external/api/api_v1/endpoints/update.py
@@ -21,28 +21,6 @@ router = APIRouter()
 LOG = logging.getLogger(__name__)
 
 
-@router.post("/validate_user/{username}/{verification_hex}")
-async def validate_user(
-    request: Request,
-    username: str,
-    verification_hex: str,
-    adapter: StatinaAdapter = Depends(get_nipt_adapter),
-):
-    update_user: User = find.user(user_name=username, adapter=adapter)
-    if update_user.verification_hex == verification_hex:
-        update_user.role = "inactive"
-        update.update_user(adapter=adapter, user=update_user)
-        email_form = FormDataRequest(
-            sender_prefix=email_settings.sender_prefix,
-            request_uri=email_settings.mail_uri,
-            recipients=email_settings.admin_email,
-            mail_title="New user request",
-            mail_body=f"User {update_user.username} ({update_user.email}) requested new account <br>"
-            f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
-        )
-        email_form.submit()
-
-
 @router.post("/update_user")
 async def update_user(
     request: Request,

--- a/statina/API/external/api/api_v1/endpoints/update.py
+++ b/statina/API/external/api/api_v1/endpoints/update.py
@@ -7,6 +7,10 @@ from fastapi.responses import RedirectResponse
 from sendmail_container import FormDataRequest
 from starlette.datastructures import FormData
 
+from statina.API.external.api.api_v1.templates.email.account_activated import (
+    ACTIVATION_MESSAGE_TEMPLATE,
+)
+from statina.API.external.api.api_v1.templates.email.admin_mail import ADMIN_MESSAGE_TEMPLATE
 from statina.adapter import StatinaAdapter
 from statina.API.external.api.deps import get_current_user
 from statina.API.external.constants import CHROM_ABNORM
@@ -45,8 +49,11 @@ async def validate_user(
                 request_uri=email_settings.mail_uri,
                 recipients=email_settings.admin_email,
                 mail_title="New user request",
-                mail_body=f"User {update_user.username} ({update_user.email}) requested new account <br>"
-                f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
+                mail_body=ADMIN_MESSAGE_TEMPLATE.format(
+                    username=update_user.username,
+                    user_email=update_user.email,
+                    website_uri=email_settings.website_uri,
+                ),
             )
             email_form.submit()
             response.set_cookie(
@@ -83,8 +90,9 @@ async def update_user(
             request_uri=email_settings.mail_uri,
             recipients=update_user.email,
             mail_title="Your account has been activated",
-            mail_body=f'Your <a href="{email_settings.website_uri}">statina</a> account ({update_user.username})'
-            f" has been activated!",
+            mail_body=ACTIVATION_MESSAGE_TEMPLATE.format(
+                website_uri=email_settings.website_uri, username=update_user.username
+            ),
         )
         email_form.submit()
     return RedirectResponse(request.headers.get("referer"))

--- a/statina/API/external/api/api_v1/endpoints/update.py
+++ b/statina/API/external/api/api_v1/endpoints/update.py
@@ -41,6 +41,7 @@ async def validate_user(
             update.update_user(adapter=adapter, user=update_user)
             email_form = FormDataRequest(
                 sender_prefix=email_settings.sender_prefix,
+                email_server_alias=email_settings.email_server_alias,
                 request_uri=email_settings.mail_uri,
                 recipients=email_settings.admin_email,
                 mail_title="New user request",
@@ -78,6 +79,7 @@ async def update_user(
     if old_role in ["inactive", "unconfirmed"] and new_role not in ["inactive", "unconfirmed"]:
         email_form = FormDataRequest(
             sender_prefix=email_settings.sender_prefix,
+            email_server_alias=email_settings.email_server_alias,
             request_uri=email_settings.mail_uri,
             recipients=update_user.email,
             mail_title="Your account has been activated",

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -38,6 +38,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
         insert_user(adapter=adapter, user=user)
         email_form = FormDataRequest(
             sender_prefix=email_settings.sender_prefix,
+            email_server_alias=email_settings.email_server_alias,
             request_uri=email_settings.mail_uri,
             recipients=user.email,
             mail_title="Verify your email",

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -50,7 +50,9 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
             recipients=user.email,
             mail_title="Verify your email",
             mail_body=CONFIRMATION_MESSAGE_TEMPLATE.format(
-                email_settings.website_uri, confirmation_link, user.username
+                website_uri=email_settings.website_uri,
+                confirmation_link=confirmation_link,
+                username=user.username,
             ),
         )
         email_form.submit()

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -50,7 +50,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
             recipients=user.email,
             mail_title="Verify your email",
             mail_body=CONFIRMATION_MESSAGE_TEMPLATE.format(
-                website_uri=email_settings.website_uri, confirmation_link=confirmation_link
+                email_settings.website_uri, confirmation_link
             ),
         )
         email_form.submit()

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -42,7 +42,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
             recipients=user.email,
             mail_title="Verify your email",
             mail_body=f"<body>Your email has been used to register account at {email_settings.website_uri} <br>"
-            f'Follow this <a href="{email_settings.website_uri}/validate_user'
+            f'Follow this <a href="{email_settings.website_uri}/login/validate_user'
             f'/{user.username}/{user.verification_hex}">link</a> to confirm your email address <br></body>',
         )
         email_form.submit()

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -50,7 +50,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
             recipients=user.email,
             mail_title="Verify your email",
             mail_body=CONFIRMATION_MESSAGE_TEMPLATE.format(
-                email_settings.website_uri, confirmation_link
+                email_settings.website_uri, confirmation_link, user.username
             ),
         )
         email_form.submit()

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -42,8 +42,9 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
             recipients=user.email,
             mail_title="Verify your email",
             mail_body=f"<body>Your email has been used to register account at {email_settings.website_uri} <br>"
-            f'Follow this <a href="{email_settings.website_uri}/login/validate_user'
-            f'/{user.username}/{user.verification_hex}">link</a> to confirm your email address <br></body>',
+            f'Follow this <a href="{email_settings.website_uri}/login/validate_user/'
+            f'?username={user.username}?verification_hex={user.verification_hex}">link</a> '
+            f"to confirm your email address <br></body>",
         )
         email_form.submit()
         response.set_cookie(key="info_type", value="success")

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -42,7 +42,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
             recipients=user.email,
             mail_title="Verify your email",
             mail_body=f"<body>Your email has been used to register account at {email_settings.website_uri} <br>"
-            f'Follow this <a href="{email_settings.website_uri}/login/validate_user/'
+            f'Follow this <a href="{email_settings.website_uri}/validate_user/'
             f'?username={user.username}&verification_hex={user.verification_hex}">link</a> '
             f"to confirm your email address <br></body>",
         )
@@ -50,8 +50,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
         response.set_cookie(key="info_type", value="success")
         response.set_cookie(
             key="user_info",
-            value=f"Your user account has been created and an email has been sent to the Statina admin. "
-            f"They will send an email to {new_user.email} when your user has been confirmed and activated.",
+            value=f"Your user account has been created and a validation email has been sent to your email address.",
         )
 
     except Exception as error:

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -43,7 +43,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
             mail_title="Verify your email",
             mail_body=f"<body>Your email has been used to register account at {email_settings.website_uri} <br>"
             f'Follow this <a href="{email_settings.website_uri}/login/validate_user/'
-            f'?username={user.username}?verification_hex={user.verification_hex}">link</a> '
+            f'?username={user.username}&verification_hex={user.verification_hex}">link</a> '
             f"to confirm your email address <br></body>",
         )
         email_form.submit()

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -54,7 +54,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
 
     except Exception as error:
         response.set_cookie(key="info_type", value="danger")
-        response.set_cookie(key="user_info", value=f"{error}")
+        response.set_cookie(key="user_info", value=f"{error.__class__.__name__}")
         pass
 
     return response

--- a/statina/API/external/api/api_v1/endpoints/user.py
+++ b/statina/API/external/api/api_v1/endpoints/user.py
@@ -41,7 +41,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
             request_uri=email_settings.mail_uri,
             recipients=email_settings.admin_email,
             mail_title="New user request",
-            mail_body=f"User {new_user.username} ({new_user.email}) requested an account <br>"
+            mail_body=f"User {new_user.username} ({new_user.email}) requested new account <br>"
             f'Follow <a href="{email_settings.website_uri}">link</a> to activate user',
         )
         email_form.submit()
@@ -54,7 +54,7 @@ async def add_new_user(request: Request, adapter: StatinaAdapter = Depends(get_n
 
     except Exception as error:
         response.set_cookie(key="info_type", value="danger")
-        response.set_cookie(key="user_info", value=f"{error.__class__.__name__}")
+        response.set_cookie(key="user_info", value=f"{error}")
         pass
 
     return response

--- a/statina/API/external/api/api_v1/templates/email/account_activated.py
+++ b/statina/API/external/api/api_v1/templates/email/account_activated.py
@@ -1,14 +1,13 @@
 # FORMAT ARGS:
 # website_uri
 # username
-# confirmation_link
 
-CONFIRMATION_MESSAGE_TEMPLATE = """
+ACTIVATION_MESSAGE_TEMPLATE = """
 <html>
   <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Statina Confirmation Email</title>
+    <title>Welcome to Statina</title>
     <style>
       img {{
         border: none;
@@ -247,21 +246,11 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
                   <table border="0" cellpadding="0" cellspacing="0">
                     <tr>
                       <td>
-                        <h1>Hello, {username} </h1>
-                        <h2>Your email has been used to register an account at <a href="{website_uri}">Statina</a>.
-                         To complete your registration, please confirm your email.</h2>      
+                        <h1>Welcome, {username} </h1>
+                        <h2>Your account at <a href="{website_uri}">Statina</a> is now activated!</h2>      
                          <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
                             <tr>
-                              <td align="left">
-                                <table border="0" cellpadding="0" cellspacing="0">
-                                  <tbody>
-                                    <tr>
-                                      <td> <a href="{confirmation_link}" target="_blank">confirm email</a> </td>
-                                    </tr>
-                                  </tbody>
-                                </table>
-                              </td>
                             </tr>
                           </tbody>
                         </table>

--- a/statina/API/external/api/api_v1/templates/email/admin_mail.py
+++ b/statina/API/external/api/api_v1/templates/email/admin_mail.py
@@ -1,14 +1,14 @@
 # FORMAT ARGS:
 # website_uri
 # username
-# confirmation_link
+# user_email
 
-CONFIRMATION_MESSAGE_TEMPLATE = """
+ADMIN_MESSAGE_TEMPLATE = """
 <html>
   <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Statina Confirmation Email</title>
+    <title>Account activation request</title>
     <style>
       img {{
         border: none;
@@ -247,21 +247,16 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
                   <table border="0" cellpadding="0" cellspacing="0">
                     <tr>
                       <td>
-                        <h1>Hello, {username} </h1>
-                        <h2>Your email has been used to register an account at <a href="{website_uri}">Statina</a>.
-                         To complete your registration, please confirm your email.</h2>      
+                        <h1>New Account Request</h1>
+                        <h2>
+                        New user with following credentials would like to to gain access to 
+                        <a href="{website_uri}">Statina</a>: <br>
+                        Username: {username} <br>
+                        Email: {user_email} <br>
+                        </h2>      
                          <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
                             <tr>
-                              <td align="left">
-                                <table border="0" cellpadding="0" cellspacing="0">
-                                  <tbody>
-                                    <tr>
-                                      <td> <a href="{confirmation_link}" target="_blank">confirm email</a> </td>
-                                    </tr>
-                                  </tbody>
-                                </table>
-                              </td>
                             </tr>
                           </tbody>
                         </table>

--- a/statina/API/external/api/api_v1/templates/email/confirmation.py
+++ b/statina/API/external/api/api_v1/templates/email/confirmation.py
@@ -1,0 +1,296 @@
+CONFIRMATION_MESSAGE_TEMPLATE = """
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Statina Confirmation Email</title>
+    <style>
+      img {
+        border: none;
+        -ms-interpolation-mode: bicubic;
+        max-width: 100%; }
+      body {
+        background-color: #f6f6f6;
+        font-family: sans-serif;
+        -webkit-font-smoothing: antialiased;
+        font-size: 14px;
+        line-height: 1.4;
+        margin: 0;
+        padding: 0; 
+        -ms-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%; }
+      table {
+        border-collapse: separate;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+        width: 100%; }
+        table td {
+          font-family: sans-serif;
+          font-size: 14px;
+          vertical-align: top; }
+      .body {
+        background-color: #f6f6f6;
+        width: 100%; }
+      .container {
+        display: block;
+        Margin: 0 auto !important;
+        /* makes it centered */
+        max-width: 580px;
+        padding: 10px;
+        width: 580px; }
+      .content {
+        box-sizing: border-box;
+        display: block;
+        Margin: 0 auto;
+        max-width: 580px;
+        padding: 10px; }
+      /* -------------------------------------
+          HEADER, FOOTER, MAIN
+      ------------------------------------- */
+      .main {
+        background: #fff;
+        border-radius: 3px;
+        width: 100%; }
+      .wrapper {
+        box-sizing: border-box;
+        padding: 20px; }
+      .footer {
+        clear: both;
+        padding-top: 10px;
+        text-align: center;
+        width: 100%; }
+        .footer td,
+        .footer p,
+        .footer span,
+        .footer a {
+          color: #999999;
+          font-size: 12px;
+          text-align: center; }
+      /* -------------------------------------
+          TYPOGRAPHY
+      ------------------------------------- */
+      h1,
+      h2,
+      h3,
+      h4 {
+        color: #000000;
+        font-family: sans-serif;
+        font-weight: 400;
+        line-height: 1.4;
+        margin: 0;
+        Margin-bottom: 30px; }
+      h1 {
+        font-size: 35px;
+        font-weight: 300;
+        text-align: center;
+        text-transform: capitalize; }
+      p,
+      ul,
+      ol {
+        font-family: sans-serif;
+        font-size: 14px;
+        font-weight: normal;
+        margin: 0;
+        Margin-bottom: 15px; }
+        p li,
+        ul li,
+        ol li {
+          list-style-position: inside;
+          margin-left: 5px; }
+      a {
+        color: #3498db;
+        text-decoration: underline; }
+      /* -------------------------------------
+          BUTTONS
+      ------------------------------------- */
+      .btn {
+        box-sizing: border-box;
+        width: 100%; }
+        .btn > tbody > tr > td {
+          padding-bottom: 15px; }
+        .btn table {
+          width: auto; }
+        .btn table td {
+          background-color: #ffffff;
+          border-radius: 5px;
+          text-align: center; }
+        .btn a {
+          background-color: #ffffff;
+          border: solid 1px #3498db;
+          border-radius: 5px;
+          box-sizing: border-box;
+          color: #3498db;
+          cursor: pointer;
+          display: inline-block;
+          font-size: 14px;
+          font-weight: bold;
+          margin: 0;
+          padding: 12px 25px;
+          text-decoration: none;
+          text-transform: capitalize; }
+      .btn-primary table td {
+        background-color: #3498db; }
+      .btn-primary a {
+        background-color: #3498db;
+        border-color: #3498db;
+        color: #ffffff; }
+      /* -------------------------------------
+          OTHER STYLES THAT MIGHT BE USEFUL
+      ------------------------------------- */
+      .last {
+        margin-bottom: 0; }
+      .first {
+        margin-top: 0; }
+      .align-center {
+        text-align: center; }
+      .align-right {
+        text-align: right; }
+      .align-left {
+        text-align: left; }
+      .clear {
+        clear: both; }
+      .mt0 {
+        margin-top: 0; }
+      .mb0 {
+        margin-bottom: 0; }
+      .preheader {
+        color: transparent;
+        display: none;
+        height: 0;
+        max-height: 0;
+        max-width: 0;
+        opacity: 0;
+        overflow: hidden;
+        mso-hide: all;
+        visibility: hidden;
+        width: 0; }
+      .powered-by a {
+        text-decoration: none; }
+      hr {
+        border: 0;
+        border-bottom: 1px solid #f6f6f6;
+        Margin: 20px 0; }
+      /* -------------------------------------
+          RESPONSIVE AND MOBILE FRIENDLY STYLES
+      ------------------------------------- */
+      @media only screen and (max-width: 620px) {
+        table[class=body] h1 {
+          font-size: 28px !important;
+          margin-bottom: 10px !important; }
+        table[class=body] p,
+        table[class=body] ul,
+        table[class=body] ol,
+        table[class=body] td,
+        table[class=body] span,
+        table[class=body] a {
+          font-size: 16px !important; }
+        table[class=body] .wrapper,
+        table[class=body] .article {
+          padding: 10px !important; }
+        table[class=body] .content {
+          padding: 0 !important; }
+        table[class=body] .container {
+          padding: 0 !important;
+          width: 100% !important; }
+        table[class=body] .main {
+          border-left-width: 0 !important;
+          border-radius: 0 !important;
+          border-right-width: 0 !important; }
+        table[class=body] .btn table {
+          width: 100% !important; }
+        table[class=body] .btn a {
+          width: 100% !important; }
+        table[class=body] .img-responsive {
+          height: auto !important;
+          max-width: 100% !important;
+          width: auto !important; }}
+      @media all {
+        .ExternalClass {
+          width: 100%; }
+        .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+          line-height: 100%; }
+        .apple-link a {
+          color: inherit !important;
+          font-family: inherit !important;
+          font-size: inherit !important;
+          font-weight: inherit !important;
+          line-height: inherit !important;
+          text-decoration: none !important; } 
+        .btn-primary table td:hover {
+          background-color: #34495e !important; }
+        .btn-primary a:hover {
+          background-color: #34495e !important;
+          border-color: #34495e !important; } }
+    </style>
+  </head>
+  <body class="">
+    <table border="0" cellpadding="0" cellspacing="0" class="body">
+      <tr>
+        <td>&nbsp;</td>
+        <td class="container">
+          <div class="content">
+            <table class="main">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper">
+                  <table border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                      <td>
+                        <h1>Confirm your email</h1>
+                        <h2>Your email has been used to register an account at <a href="{website_uri}">Statina</a>.
+                         Click on the button to confirm your email.</h2>      
+                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+                          <tbody>
+                            <tr>
+                              <td align="left">
+                                <table border="0" cellpadding="0" cellspacing="0">
+                                  <tbody>
+                                    <tr>
+                                      <td> <a href="{confirmation_link}" target="_blank">confirm email</a> </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+            <!-- START FOOTER -->
+            <div class="footer">
+              <table border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td class="content-block">
+                    <br> <a href="https://clinical.scilifelab.se/">Order Portal</a> | <a href="{website_uri}">Statina</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="content-block powered-by">
+                    Powered by <a href="https://www.scilifelab.se/facilities/clinical-genomics-stockholm/">Clinical Genomics</a>.
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <!-- END FOOTER -->
+
+          <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td>&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>"""

--- a/statina/API/external/api/api_v1/templates/email/confirmation.py
+++ b/statina/API/external/api/api_v1/templates/email/confirmation.py
@@ -5,11 +5,11 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>Statina Confirmation Email</title>
     <style>
-      img {
+      img {{
         border: none;
         -ms-interpolation-mode: bicubic;
-        max-width: 100%; }
-      body {
+        max-width: 100%; }}
+      body {{
         background-color: #f6f6f6;
         font-family: sans-serif;
         -webkit-font-smoothing: antialiased;
@@ -18,103 +18,103 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
         margin: 0;
         padding: 0; 
         -ms-text-size-adjust: 100%;
-        -webkit-text-size-adjust: 100%; }
-      table {
+        -webkit-text-size-adjust: 100%; }}
+      table {{
         border-collapse: separate;
         mso-table-lspace: 0pt;
         mso-table-rspace: 0pt;
-        width: 100%; }
-        table td {
+        width: 100%; }}
+        table td {{
           font-family: sans-serif;
           font-size: 14px;
-          vertical-align: top; }
-      .body {
+          vertical-align: top; }}
+      .body {{
         background-color: #f6f6f6;
-        width: 100%; }
-      .container {
+        width: 100%; }}
+      .container {{
         display: block;
         Margin: 0 auto !important;
         /* makes it centered */
         max-width: 580px;
         padding: 10px;
-        width: 580px; }
-      .content {
+        width: 580px; }}
+      .content {{
         box-sizing: border-box;
         display: block;
         Margin: 0 auto;
         max-width: 580px;
-        padding: 10px; }
+        padding: 10px; }}
       /* -------------------------------------
           HEADER, FOOTER, MAIN
       ------------------------------------- */
-      .main {
+      .main {{
         background: #fff;
         border-radius: 3px;
-        width: 100%; }
-      .wrapper {
+        width: 100%; }}
+      .wrapper {{
         box-sizing: border-box;
-        padding: 20px; }
-      .footer {
+        padding: 20px; }}
+      .footer {{
         clear: both;
         padding-top: 10px;
         text-align: center;
-        width: 100%; }
+        width: 100%; }}
         .footer td,
         .footer p,
         .footer span,
-        .footer a {
+        .footer a {{
           color: #999999;
           font-size: 12px;
-          text-align: center; }
+          text-align: center; }}
       /* -------------------------------------
           TYPOGRAPHY
       ------------------------------------- */
       h1,
       h2,
       h3,
-      h4 {
+      h4 {{
         color: #000000;
         font-family: sans-serif;
         font-weight: 400;
         line-height: 1.4;
         margin: 0;
-        Margin-bottom: 30px; }
-      h1 {
+        Margin-bottom: 30px; }}
+      h1 {{
         font-size: 35px;
         font-weight: 300;
         text-align: center;
-        text-transform: capitalize; }
+        text-transform: capitalize; }}
       p,
       ul,
-      ol {
+      ol {{
         font-family: sans-serif;
         font-size: 14px;
         font-weight: normal;
         margin: 0;
-        Margin-bottom: 15px; }
+        Margin-bottom: 15px; }}
         p li,
         ul li,
-        ol li {
+        ol li {{
           list-style-position: inside;
-          margin-left: 5px; }
-      a {
+          margin-left: 5px; }}
+      a {{
         color: #3498db;
-        text-decoration: underline; }
+        text-decoration: underline; }}
       /* -------------------------------------
           BUTTONS
       ------------------------------------- */
-      .btn {
+      .btn {{
         box-sizing: border-box;
-        width: 100%; }
-        .btn > tbody > tr > td {
-          padding-bottom: 15px; }
-        .btn table {
-          width: auto; }
-        .btn table td {
+        width: 100%; }}
+        .btn > tbody > tr > td {{
+          padding-bottom: 15px; }}
+        .btn table {{
+          width: auto; }}
+        .btn table td {{
           background-color: #ffffff;
           border-radius: 5px;
-          text-align: center; }
-        .btn a {
+          text-align: center; }}
+        .btn a {{
           background-color: #ffffff;
           border: solid 1px #3498db;
           border-radius: 5px;
@@ -127,33 +127,33 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
           margin: 0;
           padding: 12px 25px;
           text-decoration: none;
-          text-transform: capitalize; }
-      .btn-primary table td {
-        background-color: #3498db; }
-      .btn-primary a {
+          text-transform: capitalize; }}
+      .btn-primary table td {{
+        background-color: #3498db; }}
+      .btn-primary a {{
         background-color: #3498db;
         border-color: #3498db;
-        color: #ffffff; }
+        color: #ffffff; }}
       /* -------------------------------------
           OTHER STYLES THAT MIGHT BE USEFUL
       ------------------------------------- */
-      .last {
-        margin-bottom: 0; }
-      .first {
-        margin-top: 0; }
-      .align-center {
-        text-align: center; }
-      .align-right {
-        text-align: right; }
-      .align-left {
-        text-align: left; }
-      .clear {
-        clear: both; }
-      .mt0 {
-        margin-top: 0; }
-      .mb0 {
-        margin-bottom: 0; }
-      .preheader {
+      .last {{
+        margin-bottom: 0; }}
+      .first {{
+        margin-top: 0; }}
+      .align-center {{
+        text-align: center; }}
+      .align-right {{
+        text-align: right; }}
+      .align-left {{
+        text-align: left; }}
+      .clear {{
+        clear: both; }}
+      .mt0 {{
+        margin-top: 0; }}
+      .mb0 {{
+        margin-bottom: 0; }}
+      .preheader {{
         color: transparent;
         display: none;
         height: 0;
@@ -163,69 +163,69 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
         overflow: hidden;
         mso-hide: all;
         visibility: hidden;
-        width: 0; }
-      .powered-by a {
-        text-decoration: none; }
-      hr {
+        width: 0; }}
+      .powered-by a {{
+        text-decoration: none; }}
+      hr {{
         border: 0;
         border-bottom: 1px solid #f6f6f6;
-        Margin: 20px 0; }
+        Margin: 20px 0; }}
       /* -------------------------------------
           RESPONSIVE AND MOBILE FRIENDLY STYLES
       ------------------------------------- */
-      @media only screen and (max-width: 620px) {
-        table[class=body] h1 {
+      @media only screen and (max-width: 620px) {{
+        table[class=body] h1 {{
           font-size: 28px !important;
-          margin-bottom: 10px !important; }
+          margin-bottom: 10px !important; }}
         table[class=body] p,
         table[class=body] ul,
         table[class=body] ol,
         table[class=body] td,
         table[class=body] span,
-        table[class=body] a {
-          font-size: 16px !important; }
+        table[class=body] a {{
+          font-size: 16px !important; }}
         table[class=body] .wrapper,
-        table[class=body] .article {
-          padding: 10px !important; }
-        table[class=body] .content {
-          padding: 0 !important; }
-        table[class=body] .container {
+        table[class=body] .article {{
+          padding: 10px !important; }}
+        table[class=body] .content {{
+          padding: 0 !important; }}
+        table[class=body] .container {{
           padding: 0 !important;
-          width: 100% !important; }
-        table[class=body] .main {
+          width: 100% !important; }}
+        table[class=body] .main {{
           border-left-width: 0 !important;
           border-radius: 0 !important;
-          border-right-width: 0 !important; }
-        table[class=body] .btn table {
-          width: 100% !important; }
-        table[class=body] .btn a {
-          width: 100% !important; }
-        table[class=body] .img-responsive {
+          border-right-width: 0 !important; }}
+        table[class=body] .btn table {{
+          width: 100% !important; }}
+        table[class=body] .btn a {{
+          width: 100% !important; }}
+        table[class=body] .img-responsive {{
           height: auto !important;
           max-width: 100% !important;
-          width: auto !important; }}
-      @media all {
-        .ExternalClass {
-          width: 100%; }
+          width: auto !important; }}}}
+      @media all {{
+        .ExternalClass {{
+          width: 100%; }}
         .ExternalClass,
         .ExternalClass p,
         .ExternalClass span,
         .ExternalClass font,
         .ExternalClass td,
-        .ExternalClass div {
-          line-height: 100%; }
-        .apple-link a {
+        .ExternalClass div {{
+          line-height: 100%; }}
+        .apple-link a {{
           color: inherit !important;
           font-family: inherit !important;
           font-size: inherit !important;
           font-weight: inherit !important;
           line-height: inherit !important;
-          text-decoration: none !important; } 
-        .btn-primary table td:hover {
-          background-color: #34495e !important; }
-        .btn-primary a:hover {
+          text-decoration: none !important; }} 
+        .btn-primary table td:hover {{
+          background-color: #34495e !important; }}
+        .btn-primary a:hover {{
           background-color: #34495e !important;
-          border-color: #34495e !important; } }
+          border-color: #34495e !important; }} }}
     </style>
   </head>
   <body class="">
@@ -243,7 +243,7 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
                     <tr>
                       <td>
                         <h1>Confirm your email</h1>
-                        <h2>Your email has been used to register an account at <a href="{website_uri}">Statina</a>.
+                        <h2>Your email has been used to register an account at <a href="{0}">Statina</a>.
                          Click on the button to confirm your email.</h2>      
                          <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
@@ -252,7 +252,7 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
                                 <table border="0" cellpadding="0" cellspacing="0">
                                   <tbody>
                                     <tr>
-                                      <td> <a href="{confirmation_link}" target="_blank">confirm email</a> </td>
+                                      <td> <a href="{1}" target="_blank">confirm email</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -274,12 +274,13 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
               <table border="0" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <br> <a href="https://clinical.scilifelab.se/">Order Portal</a> | <a href="{website_uri}">Statina</a>
+                    <br> <a href="https://clinical.scilifelab.se/">Order Portal</a> | <a href="{0}">Statina</a>
                   </td>
                 </tr>
                 <tr>
                   <td class="content-block powered-by">
-                    Powered by <a href="https://www.scilifelab.se/facilities/clinical-genomics-stockholm/">Clinical Genomics</a>.
+                    Powered by <a href="https://www.scilifelab.se/facilities/clinical-genomics-stockholm/">
+                    Clinical Genomics</a>.
                   </td>
                 </tr>
               </table>

--- a/statina/API/external/api/api_v1/templates/email/confirmation.py
+++ b/statina/API/external/api/api_v1/templates/email/confirmation.py
@@ -242,9 +242,9 @@ CONFIRMATION_MESSAGE_TEMPLATE = """
                   <table border="0" cellpadding="0" cellspacing="0">
                     <tr>
                       <td>
-                        <h1>Confirm your email</h1>
+                        <h1>Hello, {2} </h1>
                         <h2>Your email has been used to register an account at <a href="{0}">Statina</a>.
-                         Click on the button to confirm your email.</h2>      
+                         To complete your registration, please confirm your email.</h2>      
                          <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
                             <tr>

--- a/statina/API/external/api/api_v1/templates/users.html
+++ b/statina/API/external/api/api_v1/templates/users.html
@@ -38,6 +38,8 @@
                                                             </option>
                                                             <option {% if user.role=='RW' %}selected{% endif %}>RW
                                                             </option>
+                                                            <option {% if user.role=='unconfirmed' %}selected{% endif %}>unconfirmed
+                                                            </option>
                                                             <option {% if user.role=='admin' %}selected{% endif %}>
                                                                 admin
                                                             </option>

--- a/statina/config.py
+++ b/statina/config.py
@@ -37,6 +37,7 @@ class EmailSettings(BaseSettings):
 
     class Config:
         env_file = str(ENV_FILE)
+        validate_assignment = True
 
 
 settings = Settings()

--- a/statina/config.py
+++ b/statina/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseSettings, EmailStr
+from pydantic import BaseSettings
 from pymongo import MongoClient
 
 from statina.adapter.plugin import StatinaAdapter
@@ -30,17 +30,17 @@ class Settings(BaseSettings):
 class EmailSettings(BaseSettings):
     """Settings for sending email"""
 
-    sll_port: int = 465
-    smtp_server: str = "smtp.gmail.com"
-    sender_email: EmailStr
-    sender_password: str
-    admin_email: EmailStr
+    admin_email: str
+    sender_prefix: str
+    mail_uri: str
+    website_uri: str
 
     class Config:
         env_file = str(ENV_FILE)
 
 
 settings = Settings()
+email_settings = EmailSettings()
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 

--- a/statina/config.py
+++ b/statina/config.py
@@ -35,6 +35,7 @@ class EmailSettings(BaseSettings):
     sender_prefix: Optional[str]
     mail_uri: Optional[str]
     website_uri: Optional[str]
+    email_server_alias: Optional[str]
 
     class Config:
         env_file = str(ENV_FILE)

--- a/statina/config.py
+++ b/statina/config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseSettings
@@ -30,14 +31,13 @@ class Settings(BaseSettings):
 class EmailSettings(BaseSettings):
     """Settings for sending email"""
 
-    admin_email: str
-    sender_prefix: str
-    mail_uri: str
-    website_uri: str
+    admin_email: Optional[str]
+    sender_prefix: Optional[str]
+    mail_uri: Optional[str]
+    website_uri: Optional[str]
 
     class Config:
         env_file = str(ENV_FILE)
-        validate_assignment = True
 
 
 settings = Settings()

--- a/statina/models/database/user.py
+++ b/statina/models/database/user.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Literal
+import secrets
 
 from pydantic import BaseModel, EmailStr
 
@@ -8,5 +9,6 @@ class User(BaseModel):
     username: str
     email: EmailStr
     added: datetime
-    role: Literal["R", "RW", "inactive", "admin"]
+    role: Literal["R", "RW", "inactive", "admin", "unconfirmed"]
     hashed_password: str
+    verification_hex: str = secrets.token_hex(64)

--- a/statina/models/database/user.py
+++ b/statina/models/database/user.py
@@ -17,4 +17,4 @@ class User(BaseModel):
         "admin",
     ]
     hashed_password: str
-    verification_hex: str = secrets.token_hex(64)
+    verification_hex: str = secrets.token_urlsafe(64)

--- a/statina/models/database/user.py
+++ b/statina/models/database/user.py
@@ -9,6 +9,12 @@ class User(BaseModel):
     username: str
     email: EmailStr
     added: datetime
-    role: Literal["R", "RW", "inactive", "admin", "unconfirmed"]
+    role: Literal[
+        "unconfirmed",
+        "inactive",
+        "R",
+        "RW",
+        "admin",
+    ]
     hashed_password: str
     verification_hex: str = secrets.token_hex(64)

--- a/statina/models/server/new_user.py
+++ b/statina/models/server/new_user.py
@@ -15,13 +15,3 @@ class NewUser(BaseModel):
         if v != values["password_repeated"]:
             raise MissMatchingPasswordError
         return v
-
-
-class NewUserRequestEmail(EmailSettings):
-    subject: str = "Statina User Request"
-    user_email: EmailStr
-    message: str
-
-    @validator("message", always=True)
-    def make_message(cls, v, values: dict) -> str:
-        return f"User request from {v}. Give the user proper credentials and send an email to {values['user_email']} when done."

--- a/statina/tools/email.py
+++ b/statina/tools/email.py
@@ -1,0 +1,5 @@
+from sendmail_container import FormDataRequest
+
+
+def send_email(email_form: FormDataRequest) -> None:
+    email_form.submit()


### PR DESCRIPTION
Addressing issue https://github.com/Clinical-Genomics/IT-issues/issues/275

### Added
* New user status "unconfirmed"
* Confirmation email sent to user at registration. Email contains 64bit hex which is also temporarily stored in database 
* Email sent to admins upon successful email confirmation


**Steps to consider while deploying**
- Configuration changes:
    - New values need updating in secret config:
    ADMIN_EMAIL
    SENDER_PREFIX
    MAIL_URI
    WEBSITE_URI
    EMAIL_SERVER_ALIAS
    - Systemd unit to be updated with argument:
    `--expose <port>`

Huge thanks to @elevu for creating the email templates :heart: 

- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


