### PR TITLE
Fix batch delete

### DIFF
--- a/statina/API/v2/endpoints/batches.py
+++ b/statina/API/v2/endpoints/batches.py
@@ -65,12 +65,12 @@ def batches(
 
 
 @router.delete("/batch/{batch_id}")
-async def batch_delete(
+def batch_delete(
     batch_id: str,
     adapter: StatinaAdapter = Depends(get_nipt_adapter),
     current_user: User = Security(get_current_active_user, scopes=["admin"]),
 ):
-    await delete_batch(adapter=adapter, batch_id=batch_id)
+    delete_batch(adapter=adapter, batch_id=batch_id)
     return JSONResponse(content=f"Deleted batch {batch_id}", status_code=200)
 
 

--- a/statina/crud/delete.py
+++ b/statina/crud/delete.py
@@ -25,7 +25,6 @@ def delete_batch_samples(adapter: StatinaAdapter, batch_id: str):
 
 
 def delete_batch(adapter: StatinaAdapter, batch_id: str):
-    samples = batch_samples(adapter=adapter, batch_id=batch_id)
     delete_batch_samples(adapter=adapter, batch_id=batch_id)
     delete_batch_document(adapter=adapter, batch_id=batch_id)
 
@@ -37,3 +36,4 @@ def delete_batches(adapter: StatinaAdapter, batches: Iterable[str]):
 
 def delete_user(adapter: StatinaAdapter, username: str):
     adapter.user_collection.delete_one({"username": username})
+    LOG.info(f"Deleting user {username}")

--- a/statina/crud/delete.py
+++ b/statina/crud/delete.py
@@ -19,10 +19,14 @@ def delete_sample_document(adapter: StatinaAdapter, sample_id: str):
     LOG.info(f"Deleting sample {sample_id}")
 
 
+def delete_batch_samples(adapter: StatinaAdapter, batch_id: str):
+    adapter.sample_collection.delete_many({"batch_id": batch_id})
+    LOG.info(f"Deleting all samples in {batch_id}")
+
+
 def delete_batch(adapter: StatinaAdapter, batch_id: str):
     samples = batch_samples(adapter=adapter, batch_id=batch_id)
-    for sample in samples:
-        delete_sample_document(adapter=adapter, sample_id=sample.sample_id)
+    delete_batch_samples(adapter=adapter, batch_id=batch_id)
     delete_batch_document(adapter=adapter, batch_id=batch_id)
 
 


### PR DESCRIPTION
### Fixed
* Deleting batch not async 
* Deleting batch deletes samples by batch filter, not sample name (otherwise will be an issue when sample reuploaded multiple times)


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


