### PR TITLE
colors instead of warnings - Can not be deployed until old statina is taken out of production

### DIFF
--- a/statina/API/external/constants.py
+++ b/statina/API/external/constants.py
@@ -1,11 +1,11 @@
 STATUS_CLASSES = {
-    "Suspected": "warning",
+    "Suspected": "gold",
     "False Positive": "success",
-    "Verified": "danger",
-    "Probable": "warning",
-    "False Negative": "danger",
-    "Other": "warning",
-    "Failed": "danger",
+    "Verified": "red",
+    "Probable": "gold",
+    "False Negative": "red",
+    "Other": "gold",
+    "Failed": "red",
 }
 
 CHROM_ABNORM = ["13", "18", "21", "X0", "XXX", "XXY", "XYY"]

--- a/statina/models/server/plots/fetal_fraction.py
+++ b/statina/models/server/plots/fetal_fraction.py
@@ -26,35 +26,35 @@ class Suspected(FetalFractionSamples):
     """Color code for suspected sample"""
 
     color: Optional[str] = "#DBA901"
-    color_group: Optional[str] = "warning"
+    color_group: Optional[str] = "gold"
 
 
 class Probable(FetalFractionSamples):
     """Color code for probable sample"""
 
     color: Optional[str] = "#0000FF"
-    color_group: Optional[str] = "warning"
+    color_group: Optional[str] = "gold"
 
 
 class FalseNegative(FetalFractionSamples):
     """Color code for false negative sample"""
 
     color: Optional[str] = "#ff6699"
-    color_group: Optional[str] = "danger"
+    color_group: Optional[str] = "red"
 
 
 class Verified(FetalFractionSamples):
     """Color code for verified sample"""
 
     color: Optional[str] = "#00CC00"
-    color_group: Optional[str] = "danger"
+    color_group: Optional[str] = "red"
 
 
 class Other(FetalFractionSamples):
     """Color code for other sample"""
 
     color: Optional[str] = "#603116"
-    color_group: Optional[str] = "warning"
+    color_group: Optional[str] = "gold"
 
 
 class FalsePositive(FetalFractionSamples):
@@ -67,7 +67,7 @@ class FalsePositive(FetalFractionSamples):
 class Failed(FetalFractionSamples):
     """Color code for failed sample"""
 
-    color_group: Optional[str] = "danger"
+    color_group: Optional[str] = "red"
 
 
 class AbNormalityClasses(BaseModel):

--- a/statina/models/server/sample.py
+++ b/statina/models/server/sample.py
@@ -14,16 +14,16 @@ from statina.models.server.plots.fetal_fraction_sex import x_get_y
 
 
 class SampleWarning(BaseModel):
-    fetal_fraction_preface: Literal["danger", "default", "warning"]
-    fetal_fraction_y: Literal["danger", "default", "warning"]
-    z_score_13: Literal["danger", "default", "warning"]
-    z_score_18: Literal["danger", "default", "warning"]
-    z_score_21: Literal["danger", "default", "warning"]
-    x0: Literal["danger", "default", "warning"]
-    xxx: Literal["danger", "default", "warning"]
-    other: Literal["danger", "default", "warning"]
-    xxy: Literal["danger", "default", "warning"]
-    xyy: Literal["danger", "default", "warning"]
+    fetal_fraction_preface: Literal["red", "default", "gold"]
+    fetal_fraction_y: Literal["red", "default", "gold"]
+    z_score_13: Literal["red", "default", "gold"]
+    z_score_18: Literal["red", "default", "gold"]
+    z_score_21: Literal["red", "default", "gold"]
+    x0: Literal["red", "default", "gold"]
+    xxx: Literal["red", "default", "gold"]
+    other: Literal["red", "default", "gold"]
+    xxy: Literal["red", "default", "gold"]
+    xyy: Literal["red", "default", "gold"]
 
 
 class Status(BaseModel):
@@ -172,7 +172,7 @@ class SampleValidator(DataBaseSample):
         if not values.get("warnings"):
             return ""
         text_warnings = [
-            abn for abn, warning in values["warnings"].dict().items() if warning == "danger"
+            abn for abn, warning in values["warnings"].dict().items() if warning == "red"
         ]
         return ", ".join(text_warnings)
 
@@ -203,19 +203,19 @@ class SampleValidator(DataBaseSample):
             if fetal_fraction_pf >= preface_threshold and (
                 z_score >= hard_max or z_score <= hard_min
             ):
-                return "danger"
+                return "red"
             elif fetal_fraction_pf < preface_threshold and (
                 z_score >= soft_max or z_score <= hard_min
             ):
-                return "warning"
+                return "gold"
         elif fetal_fraction_y >= fetal_fraction_y_threshold and (
             z_score >= hard_max or z_score <= hard_min
         ):
-            return "danger"
+            return "red"
         elif fetal_fraction_y < fetal_fraction_y_threshold and (
             z_score >= soft_max or z_score <= hard_min
         ):
-            return "warning"
+            return "gold"
         return "default"
 
     @classmethod
@@ -226,7 +226,7 @@ class SampleValidator(DataBaseSample):
             return "default"
 
         if fetal_fraction_y < FF_TRESHOLDS["fetal_fraction_y_max"] and fetal_fraction_y != 0:
-            return "danger"
+            return "red"
 
         return "default"
 
@@ -244,7 +244,7 @@ class SampleValidator(DataBaseSample):
             return "default"
 
         if fetal_fraction_y < y_treshold and fetal_fraction_x > x_treshold:
-            return "danger"
+            return "red"
 
         return "default"
 
@@ -262,7 +262,7 @@ class SampleValidator(DataBaseSample):
             return "default"
 
         if fetal_fraction_y < y_treshold and fetal_fraction_x < x_treshold:
-            return "danger"
+            return "red"
 
         return "default"
 
@@ -273,7 +273,7 @@ class SampleValidator(DataBaseSample):
         if not isinstance(fetal_fraction_pf, (float, int)):
             return "default"
         if fetal_fraction_pf < FF_TRESHOLDS["fetal_fraction_preface"]:
-            return "danger"
+            return "red"
         return "default"
 
     @classmethod
@@ -291,7 +291,7 @@ class SampleValidator(DataBaseSample):
             return "default"
 
         if y_treshold < fetal_fraction_y <= x_get_y(x=fetal_fraction_x, k=k_lower, m=m_lower):
-            return "danger"
+            return "red"
 
         return "default"
 
@@ -312,7 +312,7 @@ class SampleValidator(DataBaseSample):
         if fetal_fraction_y > x_get_y(x=fetal_fraction_x, k=k_upper, m=m_upper) and (
             fetal_fraction_x <= x_threshold
         ):
-            return "danger"
+            return "red"
         return "default"
 
     @classmethod
@@ -332,7 +332,7 @@ class SampleValidator(DataBaseSample):
         if fetal_fraction_y > x_get_y(x=fetal_fraction_x, k=k_upper, m=m_upper) and (
             fetal_fraction_x > x_treshold
         ):
-            return "danger"
+            return "red"
         return "default"
 
     class Config:


### PR DESCRIPTION
### Changed
- sample warnings being encoded with colors: red/cold instead of danger/warning


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


