### PR TITLE
(Pydantic) Fix pydantic version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8-slim-bullseye
 
 LABEL base_image="python:3.8-slim"
 LABEL about.home="https://github.com/Clinical-Genomics/statina"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ bump2version
 pymongo
 mongo_adapter
 coloredlogs
+pydantic<2.0.0
 pyyaml
 
 cerberus


### PR DESCRIPTION
### Description
The pydantic version is not locked so it automatically installs pydantic v2. This is a problem since our code is incompatible with pydantic v2.

The crux is that fastapi seems to parse which pydantic version is installed and changes adapts to the version. This unfortunately means that just changing `pydantic` imports to `pydantic.v1` seems to not work.

### Changed

- Locked pydantic version to lesser than 2.0.0
- Changed docker base image to `python:3.8-slim-bullseye`

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


