### PR TITLE
fix(Docker) Change container base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8-slim-bullseye
 
 LABEL base_image="python:3.8-slim"
 LABEL about.home="https://github.com/Clinical-Genomics/statina"


### PR DESCRIPTION
### Description
It was discovered a while ago that the pythonXX-slim base images were not able to create worker threads (see [this issue](https://github.com/Clinical-Genomics/IT-issues/issues/698)). This PR change the base image to `python:3.8-slim-bullseye`

### Changed
- Base image change to `python:3.8-slim-bullseye`


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


