### PR TITLE
patch login issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,14 +13,14 @@ email-validator
 jinja2
 
 # server stuff
-passlib
+passlib==1.7.4 # Compatible with bcrypt
 fastapi
 uvicorn
 uvloop
 httptools
 gunicorn
 python-jose[cryptography]
-bcrypt
+bcrypt==4.0.1 # Compatible with passlib
 numpy
 aiofiles
 sendmail-container


### PR DESCRIPTION

The bcrypt Python package removed the __about__ submodule in version 4.1.0 (released late 2023). Before that, the version string lived at bcrypt.__about__.__version__, which is exactly what passlib reads to detect which bcrypt backend it's working with.

### Changed
- Lock version passlib and bcrypt

**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


