### PR TITLE
Parse the data set in the batch request

### DIFF
--- a/statina/API/v2/endpoints/batches.py
+++ b/statina/API/v2/endpoints/batches.py
@@ -91,7 +91,9 @@ def load_batch(
     if not nipt_results.exists():
         return JSONResponse(content="Results file missing", status_code=422)
     samples: List[DataBaseSample] = get_samples(nipt_results)
-    batch: DatabaseBatch = crud_get_batch(data_set=batch_files.data_set, nipt_results_path=nipt_results)
+    batch: DatabaseBatch = crud_get_batch(
+        data_set=batch_files.data_set, nipt_results_path=nipt_results
+    )
     if statina.crud.find.batches.batch(adapter=adapter, batch_id=batch.batch_id):
         return JSONResponse(content="Batch already in database!", status_code=422)
     insert_batch(adapter=adapter, batch=batch, batch_files=batch_files)

--- a/statina/API/v2/endpoints/batches.py
+++ b/statina/API/v2/endpoints/batches.py
@@ -91,7 +91,7 @@ def load_batch(
     if not nipt_results.exists():
         return JSONResponse(content="Results file missing", status_code=422)
     samples: List[DataBaseSample] = get_samples(nipt_results)
-    batch: DatabaseBatch = crud_get_batch(nipt_results)
+    batch: DatabaseBatch = crud_get_batch(data_set=batch_files.data_set, nipt_results_path=nipt_results)
     if statina.crud.find.batches.batch(adapter=adapter, batch_id=batch.batch_id):
         return JSONResponse(content="Batch already in database!", status_code=422)
     insert_batch(adapter=adapter, batch=batch, batch_files=batch_files)

--- a/statina/models/database/batch.py
+++ b/statina/models/database/batch.py
@@ -21,7 +21,7 @@ class DatabaseBatch(BaseModel):
     Stdev_X: Optional[float]
     Stdev_Y: Optional[float]
     comment: Optional[str] = ""
-    dataset: Optional[str] = "default"
+    dataset: str
 
     class Config:
         validate_assignment = True

--- a/statina/models/server/load.py
+++ b/statina/models/server/load.py
@@ -5,6 +5,7 @@ from typing_extensions import Literal
 
 
 class BatchRequestBody(BaseModel):
+    data_set: str
     result_file: str
     multiqc_report: Optional[str]
     segmental_calls: Optional[str]

--- a/statina/parse/batch.py
+++ b/statina/parse/batch.py
@@ -63,7 +63,7 @@ def get_batch(data_set: str, nipt_results_path: Path) -> DatabaseBatch:
     """Parse NIPT result file and create a batch from the first sample info and the data set."""
 
     sample_data: List[dict] = parse_csv(nipt_results_path)
+    sample_data[0]["dataset"] = data_set
 
     batch = DatabaseBatch.parse_obj(sample_data[0])
-    batch.dataset = data_set
     return batch

--- a/statina/parse/batch.py
+++ b/statina/parse/batch.py
@@ -59,9 +59,11 @@ def get_samples(nipt_results_path: Path) -> List[DataBaseSample]:
     return parse_obj_as(List[DataBaseSample], parse_csv(nipt_results_path))
 
 
-def get_batch(nipt_results_path: Path) -> DatabaseBatch:
-    """Parse NIPT result file and create a batch object from the first sample information"""
+def get_batch(data_set: str, nipt_results_path: Path) -> DatabaseBatch:
+    """Parse NIPT result file and create a batch from the first sample info and the data set."""
 
     sample_data: List[dict] = parse_csv(nipt_results_path)
 
-    return DatabaseBatch.parse_obj(sample_data[0])
+    batch = DatabaseBatch.parse_obj(sample_data[0])
+    batch.dataset = data_set
+    return batch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,10 @@ def valid_load_user():
 @pytest.fixture(scope="function")
 def valid_load_batch(multiqc_report, segmental_calls, valid_csv):
     batch_files = BatchRequestBody(
-        data_set="data_set", multiqc_report=multiqc_report, segmental_calls=segmental_calls, result_file=valid_csv
+        data_set="data_set",
+        multiqc_report=multiqc_report,
+        segmental_calls=segmental_calls,
+        result_file=valid_csv,
     )
     return batch_files
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def valid_load_user():
 @pytest.fixture(scope="function")
 def valid_load_batch(multiqc_report, segmental_calls, valid_csv):
     batch_files = BatchRequestBody(
-        multiqc_report=multiqc_report, segmental_calls=segmental_calls, result_file=valid_csv
+        data_set="data_set", multiqc_report=multiqc_report, segmental_calls=segmental_calls, result_file=valid_csv
     )
     return batch_files
 

--- a/tests/crud/load/test_load.py
+++ b/tests/crud/load/test_load.py
@@ -1,5 +1,10 @@
+from pathlib import Path
+
+from pymongo.database import Database
+
 from statina.adapter.plugin import StatinaAdapter
 from statina.crud.insert import insert_batch, insert_user
+from statina.models.server.load import BatchRequestBody
 from statina.parse.batch import get_batch, get_samples
 
 
@@ -14,15 +19,15 @@ def test_load_user(database, valid_load_user):
     assert nipt_adapter.user_collection.estimated_document_count() == 1
 
 
-def test_batch_valid_files(database, valid_csv, valid_load_batch):
+def test_batch_valid_files(database: Database, valid_csv: Path, valid_load_batch: BatchRequestBody):
     # GIVEN the following request data:
     #   a valid csv file with three samples
     #   segmental_calls and multiqc_report files with random content, but that do exist.
     nipt_adapter = StatinaAdapter(database.client, db_name="test")
-    batch = get_batch(valid_csv)
+    batch = get_batch(data_set="data_set", nipt_results_path=valid_csv)
 
     # WHEN running insert_batch
-    insert_batch(nipt_adapter, batch, valid_load_batch)
+    insert_batch(adapter=nipt_adapter, batch=batch, batch_files=valid_load_batch)
 
     # THEN the batch should be added to the batch collection
     assert nipt_adapter.batch_collection.estimated_document_count() == 1

--- a/tests/parse/test_parse_batch.py
+++ b/tests/parse/test_parse_batch.py
@@ -84,10 +84,13 @@ def test_get_batch(valid_csv: Path):
     # GIVEN a valid csv file
 
     # WHEN running get_samples
-    results: DatabaseBatch = get_batch(valid_csv)
+    results: DatabaseBatch = get_batch(data_set="data_set", nipt_results_path=valid_csv)
 
     # THEN assert that the objects are samples
     assert isinstance(results, DatabaseBatch)
+
+    # THEN the data set should have been set
+    assert results.dataset == "data_set"
 
 
 def test_get_batch_with_missing_sample_project_in_csv(csv_with_missing_sample_project):
@@ -96,4 +99,4 @@ def test_get_batch_with_missing_sample_project_in_csv(csv_with_missing_sample_pr
     # WHEN running get_samples
     # THEN pydantic ValidationError is being raised
     with pytest.raises(ValidationError):
-        get_batch(csv_with_missing_sample_project)
+        get_batch(data_set="data_set", nipt_results_path=csv_with_missing_sample_project)


### PR DESCRIPTION
### Added

- Parses the data set that will be sent in the request towards the batch endpoint and uses it to create the Batch database object.

### Changed

### Fixed


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


