### PR TITLE
Add ratio warnings

### DIFF
--- a/statina/models/server/sample.py
+++ b/statina/models/server/sample.py
@@ -118,19 +118,19 @@ class SampleValidator(DataBaseSample):
         )
         sample_warnings["chr13_ratio"]: str = cls.get_tris_warning(
             dataset=dataset,
-            z_score=values.get("Chr13_Ratio"),
+            ratio=values.get("Chr13_Ratio"),
             fetal_fraction_pf=fetal_fraction_pf,
             fetal_fraction_y=fetal_fraction_y,
         )
         sample_warnings["chr18_ratio"]: str = cls.get_tris_warning(
             dataset=dataset,
-            z_score=values.get("Chr18_Ratio"),
+            ratio=values.get("Chr18_Ratio"),
             fetal_fraction_pf=fetal_fraction_pf,
             fetal_fraction_y=fetal_fraction_y,
         )
         sample_warnings["chr21_ratio"]: str = cls.get_tris_warning(
             dataset=dataset,
-            z_score=values.get("Chr21_Ratio"),
+            ratio=values.get("Chr21_Ratio"),
             fetal_fraction_pf=fetal_fraction_pf,
             fetal_fraction_y=fetal_fraction_y,
         )
@@ -206,7 +206,7 @@ class SampleValidator(DataBaseSample):
 
     @classmethod
     def get_tris_warning(
-        cls, z_score: float, fetal_fraction_pf: float, fetal_fraction_y: float, dataset: Any
+        cls, ratio: float, fetal_fraction_pf: float, fetal_fraction_y: float, dataset: Any
     ) -> str:
         """Get automated trisomy warning, based on preset Zscore thresholds"""
         hard_max = dataset.trisomy_hard_max
@@ -215,16 +215,16 @@ class SampleValidator(DataBaseSample):
         preface_threshold = dataset.fetal_fraction_preface
         fetal_fraction_y_threshold = dataset.fetal_fraction_y_for_trisomy
 
-        if fetal_fraction_pf is None or z_score is None or fetal_fraction_y is None:
+        if fetal_fraction_pf is None or ratio is None or fetal_fraction_y is None:
             return "default"
-        if z_score >= hard_max:
+        if ratio >= hard_max:
             return "danger"
-        elif z_score >= soft_max and (
+        elif ratio >= soft_max and (
             (fetal_fraction_y < fetal_fraction_y_threshold and fetal_fraction_y != 0)
             or fetal_fraction_pf < preface_threshold
         ):
             return "warning"
-        elif z_score <= hard_min:
+        elif ratio <= hard_min:
             return "danger"
         return "default"
 

--- a/statina/models/server/sample.py
+++ b/statina/models/server/sample.py
@@ -116,21 +116,21 @@ class SampleValidator(DataBaseSample):
         sample_warnings["xxy"]: str = cls.get_XXY_warning(
             dataset=dataset, fetal_fraction_y=fetal_fraction_y, fetal_fraction_x=fetal_fraction_x
         )
-        sample_warnings["z_score_13"]: str = cls.get_tris_warning(
+        sample_warnings["chr13_ratio"]: str = cls.get_tris_warning(
             dataset=dataset,
-            z_score=values.get("Zscore_13"),
+            z_score=values.get("Chr13_Ratio"),
             fetal_fraction_pf=fetal_fraction_pf,
             fetal_fraction_y=fetal_fraction_y,
         )
-        sample_warnings["z_score_18"]: str = cls.get_tris_warning(
+        sample_warnings["chr18_ratio"]: str = cls.get_tris_warning(
             dataset=dataset,
-            z_score=values.get("Zscore_18"),
+            z_score=values.get("Chr18_Ratio"),
             fetal_fraction_pf=fetal_fraction_pf,
             fetal_fraction_y=fetal_fraction_y,
         )
-        sample_warnings["z_score_21"]: str = cls.get_tris_warning(
+        sample_warnings["chr21_ratio"]: str = cls.get_tris_warning(
             dataset=dataset,
-            z_score=values.get("Zscore_21"),
+            z_score=values.get("Chr21_Ratio"),
             fetal_fraction_pf=fetal_fraction_pf,
             fetal_fraction_y=fetal_fraction_y,
         )

--- a/statina/models/server/sample.py
+++ b/statina/models/server/sample.py
@@ -208,7 +208,7 @@ class SampleValidator(DataBaseSample):
     def get_tris_warning(
         cls, ratio: float, fetal_fraction_pf: float, fetal_fraction_y: float, dataset: Any
     ) -> str:
-        """Get automated trisomy warning, based on preset Zscore thresholds"""
+        """Get automated trisomy warning, based on preset ratio thresholds"""
         hard_max = dataset.trisomy_hard_max
         soft_max = dataset.trisomy_soft_max
         hard_min = dataset.trisomy_hard_min

--- a/statina/models/server/sample.py
+++ b/statina/models/server/sample.py
@@ -14,9 +14,9 @@ from statina.models.server.plots.fetal_fraction_sex import x_get_y
 class SampleWarning(BaseModel):
     fetal_fraction_preface: Literal["danger", "default", "warning"]
     fetal_fraction_y: Literal["danger", "default", "warning"]
-    z_score_13: Literal["danger", "default", "warning"]
-    z_score_18: Literal["danger", "default", "warning"]
-    z_score_21: Literal["danger", "default", "warning"]
+    chr13_ratio: Literal["danger", "default", "warning"]
+    chr18_ratio: Literal["danger", "default", "warning"]
+    chr21_ratio: Literal["danger", "default", "warning"]
     x0: Literal["danger", "default", "warning"]
     xxx: Literal["danger", "default", "warning"]
     other: Literal["danger", "default", "warning"]


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/statina-ui/issues/227.

### Added

### Changed

- Z_score warnings are changed to ratio warnings and are calculated using the ratios instead

### Fixed


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


