### PR TITLE
Patch sorting in summary table

### DIFF
--- a/statina/constants.py
+++ b/statina/constants.py
@@ -29,14 +29,13 @@ sample_status_options = Literal[
 sample_sort_keys = Literal[
     "sample_id",
     "batch_id",
-    "Zscore_13",
-    "Zscore_18",
-    "Zscore_21",
-    "Zscore_X",
     "FF_Formatted",
     "CNVSegment",
     "FFY",
     "FFX",
     "comment",
     "QCFlag",
+    "Chr13_Ratio",
+    "Chr18_Ratio",
+    "Chr21_Ratio",
 ]


### PR DESCRIPTION

### Fixed
- Chr13_Ratio, Chr18_Ratio, and Chr21_Ratio added to sample_sort_keys — sorting by these fields returned 422 because they were missing from the allowed Literal type


**Steps to consider while deploying**
- Configuration changes:
- Documentation updates:
- Inform users by email:

### Review:
- [ ] Code approved by
- [ ] Tests executed on stage by:  (Document the test done with screen shots and description.)
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


